### PR TITLE
Integrate mermaid to jekyll

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,6 +8,9 @@
 
     gtag('config', 'G-2CHF4K157C');
   </script>
+  <!-- mermaid -->
+  <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
+  <script>mermaid.initialize({startOnLoad:true});</script>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
We can use `div` to add mermaid blocks to post markdown:

```html
<div class="mermaid">
graph TD;
    A-->B;
    A-->C;
    B-->D;
    C-->D;
</div>
```

It doesn't support code block with mermaid class.

In VSCode, we can use
https://marketplace.visualstudio.com/items?itemName=bierner.markdown-mermaid
to preview mermaid content when writing.