### PR TITLE
Revert jekyll-remote-include

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,3 @@ end
 # Performance-booster for watching directories on Windows
 gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
 
-# See https://github.com/netrics/jekyll-remote-include
-group :jekyll_plugins do
-    gem 'jekyll-remote-include', :github => 'netrics/jekyll-remote-include'
-end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,3 @@
-GIT
-  remote: https://github.com/netrics/jekyll-remote-include.git
-  revision: 39ae1a1744c8837d5ee64b11c5f982304ea940e5
-  specs:
-    jekyll-remote-include (1.0.2)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -82,7 +76,6 @@ PLATFORMS
 DEPENDENCIES
   jekyll (~> 4.3.2)
   jekyll-feed (~> 0.17)
-  jekyll-remote-include!
   minima (~> 2.5)
   tzinfo (~> 1.2)
   tzinfo-data

--- a/_config.yml
+++ b/_config.yml
@@ -25,7 +25,6 @@ theme: minima
 plugins:
   - jekyll-feed
   - jekyll-seo-tag
-  - jekyll-remote-include
 
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list

--- a/about.md
+++ b/about.md
@@ -3,4 +3,5 @@ layout: page
 title: About
 permalink: /about/
 ---
+Github: <https://github.com/utzcoz>
 

--- a/about.md
+++ b/about.md
@@ -4,4 +4,3 @@ title: About
 permalink: /about/
 ---
 
-{% remote_include https://raw.githubusercontent.com/utzcoz/utzcoz/main/README.md %}


### PR DESCRIPTION
GitHub Page doesn't support custom plugin based on Git. This PR removes `jekyll-remote-include` plugin before I find proper solution to fix it.